### PR TITLE
Add 127250 heading (magnetic) conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Bacon = require("baconjs");
-const debug = require("debug")("signalk-to-nmea2000");
+const debug = require("debug")("signalk:signalk-to-nmea2000");
 const util = require("util");
 
 module.exports = function(app) {
@@ -35,7 +35,7 @@ module.exports = function(app) {
     }
   };
   plugin.start = function(options) {
-    debug("signalk-to-nmea2000: start");
+    debug("start");
     const selfContext = "vessels." + app.selfId;
     const selfMatcher = delta => delta.context && delta.context === selfContext;
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
   "license": "ISC",
   "dependencies": {
     "baconjs": "^0.7.88",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "to-n2k": "github:tkurki/to-n2k"
   },
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/sbender9/signalk-to-nmea2000"
+    "type": "git",
+    "url": "https://github.com/sbender9/signalk-to-nmea2000"
   }
 }


### PR DESCRIPTION
Add conversion to 127250 heading, magnetic version, using tkurki/to-n2k,
which uses the PGN structure database from canboat to generate the messages.